### PR TITLE
Alow native terminal scrolling with tmux panes

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -38,6 +38,12 @@ bind -r L resize-pane -R 10
 bind -t vi-copy C-k page-up
 bind -t vi-copy C-j page-down
 
+# Allow native terminal scrolling within tmux panes
+set -g terminal-overrides 'xterm*:smcup@:rmcup@'
+set-option -g mouse-select-pane on
+set-option -g mouse-select-window on
+set-window-option -g mode-mouse on
+
 # ——— Misk Key speedups ————————————————————————————————————————————————————————
 
 # ALt+Tab to cycle panes (assuming your WM doesn't steal the keybinding)


### PR DESCRIPTION
This works very well with Iterm2, but not sure how well it works in other terminals (I don't have a linux machine atm to test on). Figured these are settings you may want to consider for tmux-dots. If not I can just keep them as a separate addition that I use.
